### PR TITLE
Adds access to a UIView's layer property in the styler.

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_view_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_view_styler.rb
@@ -266,6 +266,10 @@ module RubyMotionQuery
         @view.clipsToBounds
       end
 
+      def layer
+        @view.layer
+      end
+
     end
   end
 end

--- a/spec/stylers/_ui_view_styler.rb
+++ b/spec/stylers/_ui_view_styler.rb
@@ -59,6 +59,7 @@ class SyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
 
     st.scale = 1.5
     st.rotation = 45
+    st.layer.cornerRadius = 5
   end
 
 end
@@ -180,5 +181,6 @@ describe 'ui_view_styler' do
     view.clipsToBounds.should == false
     view.isHidden.should == true
     view.contentMode.should == UIViewContentModeBottomLeft
+    view.layer.cornerRadius.should == 5
   end
 end


### PR DESCRIPTION
`280 specifications (724 requirements), 0 failures, 0 errors`

I needed to access the view's `layer` in the styler so that I could set things like `masksToBounds` and `cornerRadius`.
