### PR TITLE
Modify readme for better reference & searchability

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ class MainController < UIViewController
   def viewDidLoad
     super
 
-    rmq.stylesheet = MainControllerStyleSheet
+    rmq.stylesheet = MainStyleSheet
     view.rmq.apply_style :root_view
 
     @title_label = rmq.append(UILabel, :title_label).get


### PR DESCRIPTION
I was putting together some stylesheets by hand and had a minor trip-up when the stylesheet class was called `MainStylesheet` in one place and `MainControllerStylesheet` in another. This just makes them consistent in the readme.
