### PR TITLE
corrected spelling error in device orientations

### DIFF
--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -69,13 +69,17 @@ module RubyMotionQuery
         Device.orientation == :portrait || Device.orientation == :unknown
       end
 
-      ORIENTATIONS = { 
-        UIDeviceOrientationUnknown => :unkown,
+      def orientations
+        ORIENTATIONS
+      end
+
+      ORIENTATIONS = {
+        UIDeviceOrientationUnknown => :unknown,
         UIDeviceOrientationPortrait => :portrait,
         UIDeviceOrientationPortraitUpsideDown => :portrait_upside_down,
         UIDeviceOrientationLandscapeLeft => :landscape_Left,
         UIDeviceOrientationLandscapeRight => :landscape_right,
-        UIDeviceOrientationFaceUp => :face_up, 
+        UIDeviceOrientationFaceUp => :face_up,
         UIDeviceOrientationFaceDown => :face_down
       }
 

--- a/spec/device.rb
+++ b/spec/device.rb
@@ -10,5 +10,10 @@ describe 'device' do
     rmq.device.should == RubyMotionQuery::Device
   end
 
+  it 'contains "unknown" in device orientations' do
+    puts RubyMotionQuery::Device.orientations.inspect
+    RubyMotionQuery::Device.orientations[UIDeviceOrientationUnknown].should.not == nil
+  end
+
   # TODO finish
 end


### PR DESCRIPTION
I would not normally submit so trivial a pull request, but this spelling error actually seems to break device orientation detection.
