### PR TITLE
Fleshing out UITextField, and starting down a path to simplify adding new properties

### DIFF
--- a/motion/ruby_motion_query/stylers/delegatable_method.rb
+++ b/motion/ruby_motion_query/stylers/delegatable_method.rb
@@ -1,0 +1,22 @@
+module RubyMotionQuery
+  module Stylers
+    module DelegatableMethod
+      def appleize(sym)
+        items = sym.to_s.split('_')
+        ret = items.shift
+        ret += items.map { |i| i[0] = i[0].upcase ; i }.join
+      end
+
+      def delegate_method(name, target = :view, as = nil)
+        as ||= appleize(name)
+        define_method(name) do
+          send(target).send(as)
+        end
+
+        define_method("#{name}=") do |value|
+          send(target).send("#{as}=", value)
+        end
+      end
+    end
+  end
+end

--- a/motion/ruby_motion_query/stylers/protocols/ui_text_input_traits.rb
+++ b/motion/ruby_motion_query/stylers/protocols/ui_text_input_traits.rb
@@ -1,0 +1,20 @@
+module RubyMotionQuery
+  module Stylers
+    module Protocols
+
+      # UITExtInputTraits protocol
+      module UITextInputTraits
+        extend DelegatableMethod
+
+        delegate_method :autocapitalization_type
+        delegate_method :autocorrection_type
+        delegate_method :enables_return_key_automatically
+        delegate_method :keyboard_appearance
+        delegate_method :keyboard_type
+        delegate_method :return_key_type
+        delegate_method :secure_text_entry
+        delegate_method :spell_checking_type
+      end
+    end
+  end
+end

--- a/motion/ruby_motion_query/stylers/ui_button_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_button_styler.rb
@@ -1,6 +1,6 @@
 module RubyMotionQuery
   module Stylers
-    class UIButtonStyler < UIControlStyler 
+    class UIButtonStyler < UIControlStyler
 
       def text=(value)
         @view.setTitle(value, forState: UIControlStateNormal)

--- a/motion/ruby_motion_query/stylers/ui_text_field_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_text_field_styler.rb
@@ -1,8 +1,40 @@
 module RubyMotionQuery
   module Stylers
+    class UITextFieldStyler < UIControlStyler
+      include Protocols::UITextInputTraits
 
-    class UITextFieldStyler < UIControlStyler 
+      # Accessing the Text Attributes
+      delegate_method :text
+      delegate_method :attributed_text
+      delegate_method :placeholder
+      delegate_method :attributed_placeholder
+      delegate_method :default_text_attributes
+      delegate_method :font
+      delegate_method :text_color
+      delegate_method :text_alignment
+      delegate_method :typing_attributes
+
+      # Sizing the Text Field's Text
+      delegate_method :adjusts_font_size_to_fit_width
+      delegate_method :minimum_font_size
+
+      # Managing the Eiting Behavior
+      delegate_method :editing
+      delegate_method :clears_on_begin_editing
+      delegate_method :clears_on_insertion
+      delegate_method :allows_editing_text_attributes
+
+      # Setting the View's Background Appearance
+      delegate_method :border_style
+      delegate_method :background
+      delegate_method :disabled_background
+
+      # managing overlay views
+      delegate_method :clear_button_mode
+      delegate_method :left_view
+      delegate_method :left_view_mode
+      delegate_method :right_view
+      delegate_method :right_view_mode
     end
-
   end
 end

--- a/motion/ruby_motion_query/stylers/ui_view_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_view_styler.rb
@@ -3,6 +3,8 @@ module RubyMotionQuery
 
     # When you create a styler, always inherit UIViewStyler
     class UIViewStyler
+      extend DelegatableMethod
+
       def initialize(view)
         @view = view
       end

--- a/spec/stylers/ui_text_field_styler.rb
+++ b/spec/stylers/ui_text_field_styler.rb
@@ -1,0 +1,28 @@
+describe 'stylers/ui_text_field' do
+  class SyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
+    def ui_text_field_kitchen_sink(st)
+      st.text = 'foo'
+      st.placeholder = "placeholder"
+      st.border_style = UITextBorderStyleRoundedRect
+      st.autocapitalization_type = UITextAutocapitalizationTypeWords
+    end
+  end
+
+  before do
+    @vc = UIViewController.alloc.init
+    @vc.rmq.stylesheet = SyleSheetForUIViewStylerTests
+    @view_klass = UITextField
+  end
+
+  behaves_like "styler"
+
+  it 'should apply a style with every UITextFieldStyler wrapper method' do
+    view = @vc.rmq.append(@view_klass, :ui_text_field_kitchen_sink).get
+
+    view.tap do |v|
+      1.should == 1
+    end
+
+    rmq.all.log
+  end
+end


### PR DESCRIPTION
I know we didn't discuss this before I did this work, so it may come as something of a shock.  If you like this strategy, I'm happy to make more extensive changes to get all of the properties I can find into rmq for each UIView and subclasses provided, or at least the simple ones.  :)

I've made a stab at fleshing out the UITextField styling, so I can use many things that are otherwise only available through the view.

Do do this sanely, I've added a module that allows defining a method a as a simple delegate to the view, where the name foo_bar_baz is translated into fooBarBaz and values passed in to the foo_bar_baz= method are simple.

I've also started down the road of implementing protocols, so things that have a keyboard won't need to define those properties twice, they can just "include Protocols::UITextInputTraits and get all those getters and setters, or any other more elaborate methods defined there.
