### PR TITLE
updated regex for controller/stylesheet replace

### DIFF
--- a/bin/rmq
+++ b/bin/rmq
@@ -106,7 +106,7 @@ class RmqCommandLine
       return unless (@template_path = template_path(template_name))
       files = Dir["#{@template_path}**/*"].select {|f| !File.directory? f}
 
-      @name = name.gsub(/(controller|stylesheet)/,'')
+      @name = name.gsub(/_*(controller|stylesheet)/,'')
       @name_camel_case = @name.split('_').map{|word| word.capitalize}.join
 
       files.each do |template_file_path_and_name|


### PR DESCRIPTION
[Existing code](https://github.com/infinitered/rmq/blob/0fb018c2b447a7aa15dc2df184d258b7a5f2d73a/bin/rmq#L109) was replacing the word controller, but not fixing the extra underscore.  E.g.

`rmq create controller neat_cool_controller` would generate files with double underscores from the replace: ergo `neat_cool__controller`

Updated the regex to pick it up.
