### PR TITLE
Tweaking the regex

### DIFF
--- a/bin/rmq
+++ b/bin/rmq
@@ -106,7 +106,7 @@ class RmqCommandLine
       return unless (@template_path = template_path(template_name))
       files = Dir["#{@template_path}**/*"].select {|f| !File.directory? f}
 
-      @name = name.gsub(/_*(controller|stylesheet)/,'')
+      @name = name.gsub(/_?(controller|stylesheet)/,'')
       @name_camel_case = @name.split('_').map{|word| word.capitalize}.join
 
       files.each do |template_file_path_and_name|


### PR DESCRIPTION
Using the `*` is slower.  Since this item will likely only have (or should only match) a single underscore, moving it to the `?` match for zero or one, will be much faster and smarter.
