### PR TITLE
Added directional swiping events.

### DIFF
--- a/motion/ruby_motion_query/event.rb
+++ b/motion/ruby_motion_query/event.rb
@@ -52,6 +52,14 @@ module RubyMotionQuery
           o.rotation = opts[:rotation] if opts.include?(:rotation)
           o.scale = opts[:scale] if opts.include?(:scale)
 
+          case event
+            when :swipe_up then o.direction = UISwipeGestureRecognizerDirectionUp
+            when :swipe_down then o.direction = UISwipeGestureRecognizerDirectionDown
+            when :swipe_left then o.direction = UISwipeGestureRecognizerDirectionLeft
+            when :swipe_right then o.direction = UISwipeGestureRecognizerDirectionRight
+          end
+
+
           if opts.include?(:init)
             opts[:init].call(@recognizer)
           end
@@ -127,6 +135,10 @@ module RubyMotionQuery
       pinch: UIPinchGestureRecognizer,
       rotate: UIRotationGestureRecognizer,
       swipe: UISwipeGestureRecognizer,
+      swipe_up: UISwipeGestureRecognizer,
+      swipe_down: UISwipeGestureRecognizer,
+      swipe_left: UISwipeGestureRecognizer,
+      swipe_right: UISwipeGestureRecognizer,
       pan: UIPanGestureRecognizer,
       long_press: UILongPressGestureRecognizer
     }

--- a/motion/ruby_motion_query/events.rb
+++ b/motion/ruby_motion_query/events.rb
@@ -45,6 +45,10 @@ module RubyMotionQuery
     #  :pinch
     #  :rotate
     #  :swipe
+    #  :swipe_up
+    #  :swipe_down
+    #  :swipe_left
+    #  :swipe_right
     #  :pan
     #  :long_press
 

--- a/templates/collection_view_controller/app/stylesheets/name_controller_stylesheet.rb
+++ b/templates/collection_view_controller/app/stylesheets/name_controller_stylesheet.rb
@@ -19,7 +19,7 @@ class <%= @name_camel_case %>ControllerStylesheet < ApplicationStylesheet
       #cl.headerReferenceSize = [cell_size[:w], cell_size[:h]]
       cl.minimumInteritemSpacing = @margin
       cl.minimumLineSpacing = @margin
-      #cl.sectionInsert = [0,0,0,0]
+      #cl.sectionInset = [0,0,0,0]
     end
   end
 end


### PR DESCRIPTION
I needed to have a swipe up and swipe down gesture on a view.  On the callback block I couldn't figure out how to detect up or down.

So, I thought I'd attach two different gesture events and use the direction option.   RMQ wouldn't let me attach to swipes.  

Now it can.

I didn't write any tests because I'm not convinced you'll actually like this because it introduces a possible conflict between :swipe and :swipe_up.  Not sure how'd you'd like to address this.

No offense will be taken if you'd like to burn this PR to the ground.
