### PR TITLE
Compile stylesheet first

### DIFF
--- a/lib/ruby_motion_query.rb
+++ b/lib/ruby_motion_query.rb
@@ -4,7 +4,8 @@ end
 
 Motion::Project::App.setup do |app|
   parent = File.join(File.dirname(__FILE__), '..')
-  files = [File.join(parent, 'motion/ruby_motion_query/stylers/ui_view_styler.rb')]
+  files = [File.join(parent, 'motion/ruby_motion_query/stylesheet.rb')]
+  files << [File.join(parent, 'motion/ruby_motion_query/stylers/ui_view_styler.rb')]
   files << File.join(parent, 'motion/ruby_motion_query/stylers/ui_control_styler.rb')
   files << Dir.glob(File.join(parent, "motion/**/*.rb"))
   files.flatten!.uniq!


### PR DESCRIPTION
Even though I was able to recreate the issue in #71, using the sample RMQ app included with RMQ (and then have it fixed with my commit d92ea17067934a133cced391d3481a050a5cb402).  I pulled down the sample app that was provided in the bug request and ran it against RMQ edge (with my fix) and it crashed.

After this additional change the bug reported by the user using the demo app and the rmq built in sample app both work without the stylesheet crash.
