### PR TITLE
Adds validations to selectors

### DIFF
--- a/motion/ruby_motion_query/data.rb
+++ b/motion/ruby_motion_query/data.rb
@@ -16,7 +16,11 @@ module RubyMotionQuery
       @_validations ||= []
     end
 
-    # *Do not* use this, use {RMQ#tag} instead: 
+    def validations=(value)
+      @_validations = value
+    end
+
+    # *Do not* use this, use {RMQ#tag} instead:
     # @example
     #   rmq(my_view).tag(:foo)
     def tag(*tag_or_tags)
@@ -29,7 +33,7 @@ module RubyMotionQuery
         end
       elsif tag_or_tags.is_a?(Hash)
         tag_or_tags.each do |tag_name, tag_value|
-          tags[tag_name] = tag_value 
+          tags[tag_name] = tag_value
         end
       elsif tag_or_tags.is_a?(Symbol)
         tags[tag_or_tags] = 1

--- a/motion/ruby_motion_query/validation.rb
+++ b/motion/ruby_motion_query/validation.rb
@@ -18,6 +18,14 @@ module RubyMotionQuery
       self
     end
 
+    # @return [RMQ]
+    def clear_validations!
+      selected.each do |view|
+        view.rmq_data.validations = []
+      end
+      self
+    end
+
     # @return [Boolean] false if any validations fail
     def valid?
       selected.each do |view|

--- a/spec/validation.rb
+++ b/spec/validation.rb
@@ -103,5 +103,17 @@ describe 'validation' do
       vc.rmq(:three, :two).valid?.should == true
 
     end
+
+    it 'can clear all validations' do
+      vc = UIViewController.new
+
+      vc.rmq.all.valid?.should == true
+      vc.rmq.append(UITextField).validates(:digits).data('tacorama').tag(:one)
+      vc.rmq.append(UITextField).validates(:digits).data('not digits').tag(:two)
+      vc.rmq.all.valid?.should == false
+      vc.rmq.all.clear_validations!
+      vc.rmq.all.valid?.should == true
+
+    end
   end
 end


### PR DESCRIPTION
Provides some of the functionality requested in #77
- Ability to add validations on `rmq(UITextField, :email_address).validates(:email)`
- Ability to check all validations or selection of validations 
  - `rmq.all.valid?`
  - `rmq(UITextField).valid?`
