### PR TITLE
Validation arguments

### DIFF
--- a/motion/ruby_motion_query/validation.rb
+++ b/motion/ruby_motion_query/validation.rb
@@ -11,9 +11,9 @@ module RubyMotionQuery
     end
 
     # @return [RMQ]
-    def validates(rule)
+    def validates(rule, options={})
       selected.each do |view|
-        view.rmq_data.validations << Validation.new(rule)
+        view.rmq_data.validations << Validation.new(rule, options)
       end
       self
     end
@@ -53,13 +53,15 @@ module RubyMotionQuery
 
   class Validation
 
-    def initialize(rule)
+    def initialize(rule, options={})
       @rule = @@validation_methods[rule]
+      @options = options
       raise "RMQ validation error: :#{rule} is not one of the supported validation methods." unless @rule
     end
 
     def valid?(data, options={})
-      @rule.call(data, options)
+      @options = options.merge(@options)
+      @rule.call(data, @options)
     end
 
     class << self

--- a/spec/validation.rb
+++ b/spec/validation.rb
@@ -128,11 +128,16 @@ describe 'validation' do
       vc.rmq.append(UITextField).validates(:digits).data('taco loco').tag(:one)
       vc.rmq.append(UITextField).validates(:digits).data('123455').tag(:two)
       vc.rmq.append(UITextField).validates(:digits).data('1234').tag(:three)
+      # selections with options
+      vc.rmq.append(UITextField).validates(:length, min_length: 2, max_length: 10).data('1234').tag(:four)
+      vc.rmq.append(UITextField).validates(:length, exact_length: 5).data('1234').tag(:five)
 
       vc.rmq.all.valid?.should == false
       vc.rmq(:one).valid?.should == false
       vc.rmq(:one, :two).valid?.should == false
       vc.rmq(:three, :two).valid?.should == true
+      vc.rmq(:four).valid?.should == true
+      vc.rmq(:five).valid?.should == false
 
     end
 


### PR DESCRIPTION
previously we didn't have a way to add validation arguments (requested in ticket #77).   I've added them along with the new `length` validation, that shows it off.

``` ruby
@rmq.validation.valid?('test', :length, exact_length: 2..7) # true ...niceeeeeeeeeeeee
```

along with this PR, I've also tossed in new validation methods for `has_upper`, `has_lower`, and the much needed check for `strong_password`

with tests :muscle: 
