### PR TITLE
RMQ::Validation.add_validator method + spec

### DIFF
--- a/motion/ruby_motion_query/validation.rb
+++ b/motion/ruby_motion_query/validation.rb
@@ -207,6 +207,8 @@ module RubyMotionQuery
       end
 
       def add_validator(rule, &block)
+        raise(ArgumentError, "add_validator requires a block") if block.nil?
+
         @@validation_methods[rule] = block
       end
 

--- a/spec/validation.rb
+++ b/spec/validation.rb
@@ -284,6 +284,12 @@ describe 'validation' do
       end
     end
 
+    it "should raise a ArgumentError when no block is given" do
+      should.raise(ArgumentError) do
+        @rmq.validation.add_validator(:no_block)
+      end
+    end
+
     it "should not raise a RuntimeError for a missing validation method" do
       should.not.raise(RuntimeError) do
         validation = @rmq.validation.new(:start_with)


### PR DESCRIPTION
A start to #106

Edge cases and things to think about:
- How to handle an error in the users validation block.
- How to handle no block given.
- `@@validation_methods[rule]` in this implementation will be a non-Lambda Proc whereas all the others will be Lambdas
