### PR TITLE
Fixes border_color styler

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_view_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_view_styler.rb
@@ -359,7 +359,7 @@ module RubyMotionQuery
       end
 
       def border_color=(value)
-        if value.is_a?(UICachedDeviceRGBColor)
+        if is_color(value)
           @view.layer.setBorderColor(value.CGColor)
         else
           @view.layer.setBorderColor value
@@ -399,6 +399,11 @@ module RubyMotionQuery
       def alpha ; view.alpha ; end
       def alpha=(v) ; view.alpha = v ; end
 
+      private
+
+      def is_color(value)
+        [UICachedDeviceRGBColor, UIDeviceRGBColor].include?(value.class)
+      end
     end
   end
 end

--- a/spec/stylers/_ui_view_styler.rb
+++ b/spec/stylers/_ui_view_styler.rb
@@ -195,4 +195,19 @@ describe 'ui_view_styler' do
     view = @vc.rmq.append(UIView).style { |st| st.accessibility_label = value }.get
     view.accessibilityLabel.should == value
   end
+
+  it "should set the border width" do
+    view = @vc.rmq.append(UIView).style { |st| st.border_width= 12}.get
+    view.layer.borderWidth.should == 12
+  end
+
+  it "should set the border color" do
+    view = @vc.rmq.append(UIView).style { |st| st.border_color = rmq.color.red }.get
+    view.layer.borderColor.should == UIColor.redColor.CGColor
+  end
+
+  it "should set the border color for uncached colors" do
+    view = @vc.rmq.append(UIView).style { |st| st.border_color = rmq.color.from_rgba(0,0,255, 1) }.get
+    view.layer.borderColor.should == rmq.color.from_rgba(0, 0, 255, 1).CGColor
+  end
 end


### PR DESCRIPTION
using a non-cached color value (example: `rmq.color.from_hex("#333333")`) to set a border color doesn't work properly prior to this change
