### PR TITLE
removed defunct ios_eight? check

### DIFF
--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -13,10 +13,6 @@ module RubyMotionQuery
 
   class Device
     class << self
-      def ios_eight?
-        @_ios_eight ||= screen.respond_to?(:coordinateSpace)
-      end
-
       # Find out what version of iOS you're using.
       # `rmq.device.is_version? 8`
       # `rmq.device.is_version? "7.1"`


### PR DESCRIPTION
People should be using the timeless equivalent `is_version? 8`
