### PR TITLE
Updates console command help text for XCode 6

### DIFF
--- a/bin/rmq
+++ b/bin/rmq
@@ -68,10 +68,17 @@ class RmqCommandLine
       (main)> exit
 
       Then try these:
+      > rake device_name='iPhone 4s'
+      > rake device_name='iPhone 5s'
+      > rake device_name='iPhone 5s' target=7.1
+      > rake device_name='iPhone 6 Plus'
+      > rake device_name='iPad Retina'
+      > rake device
+
+      Or for XCode 5.1
       > rake retina=3.5
-      > rake retina=4 
-      > rake device_family=ipad 
-      > rake device }
+      > rake retina=4
+      > rake device_family=ipad}
 
     end
 


### PR DESCRIPTION
  Now that we default to SDK 8.1 in the new app template it make sense
  to provide the new device_name parameter
