### PR TITLE
Fixes spec crashing issue (#132)

### DIFF
--- a/spec/actions.rb
+++ b/spec/actions.rb
@@ -54,10 +54,7 @@ describe 'actions' do
 
   describe 'focus' do
     before do
-      window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
-      @vc = UIViewController.alloc.initWithNibName(nil, bundle: nil)
-      window.rootViewController = @vc
-      window.makeKeyAndVisible
+      @vc = rmq.app.window.rootViewController
 
       @tf_0 = @vc.rmq.append(UITextField).style do |st|
         st.frame = {l: 10, t: 10, w: 100, h: 30}


### PR DESCRIPTION
I believe this fixes #132 

@twerth I know we previously talked about in [@vc.rmq vs. rmq](https://github.com/infinitered/rmq/commit/ca07631fe6845abf8da1aca6a0b555740928422c), but in this case I think this makes sense.

 After this change I wrote this script, and there was no failures.  Prior to this change - spec failures happened at **least** 1/4 of the time.

``` bash
#!/usr/bin/env ruby

50.times do
  system "bundle exec rake spec && bundle exec rake crashlog"
end
```

If there was a failure then the crash log would open (as I emptied my crash log before starting) - on master i would see a crash probably 1 out of 4 times, but with this branch, 100 times - no failure!

Thanks for helping me dig into this @vaughankg!
