### PR TITLE
stopped .valid and .invalid from returning duplicates

### DIFF
--- a/motion/ruby_motion_query/validation.rb
+++ b/motion/ruby_motion_query/validation.rb
@@ -71,24 +71,16 @@ module RubyMotionQuery
 
     # @return [Array] of views where validations have failed
     def invalid
-      invalid = []
-      selected.each do |view|
-        view.rmq_data.validations.each do |validation|
-          invalid.push(view) unless validation.valid_status
-        end
+      selected.reject do |view|
+        view.rmq_data.validations.map{ |validation| validation.valid_status }.reduce(:&)
       end
-      return invalid
     end
 
-    # @return [Array] of views where validations have failed
+    # @return [Array] of views where validations have not failed
     def valid
-      invalid = []
-      selected.each do |view|
-        view.rmq_data.validations.each do |validation|
-          invalid.push(view) if validation.valid_status
-        end
+      selected.select do |view|
+        view.rmq_data.validations.map{ |validation| validation.valid_status }.reduce(:&)
       end
-      return invalid
     end
 
   end # End RMQ

--- a/spec/validation.rb
+++ b/spec/validation.rb
@@ -187,7 +187,7 @@ describe 'validation' do
     it 'maintains what selected items are invalid' do
       vc = UIViewController.alloc.init
 
-      vc.rmq.append(UITextField).validates(:digits).data('taco loco').tag(:one)
+      vc.rmq.append(UITextField).validates(:length, max_length: 1).validates(:digits).data('taco loco').tag(:one)
       vc.rmq.append(UITextField).validates(:digits).data('123455').tag(:two)
 
       #everything is valid by default
@@ -200,7 +200,7 @@ describe 'validation' do
       vc = UIViewController.alloc.init
 
       vc.rmq.append(UITextField).validates(:digits).data('taco loco').tag(:one)
-      vc.rmq.append(UITextField).validates(:digits).data('123455').tag(:two)
+      vc.rmq.append(UITextField).validates(:length, min_length: 1).validates(:digits).data('123455').tag(:two)
 
       #everything is valid by default
       vc.rmq.all.valid.size.should == 2


### PR DESCRIPTION
Hey,

Having multiple validations on a view meant that `valid` and `invalid` methods might return the same view more than once which didn't make sense to me.
