### PR TITLE
added .ios_at_least? method with tests

### DIFF
--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -26,6 +26,16 @@ module RubyMotionQuery
         UIDevice.currentDevice.systemVersion
       end
 
+      # Identify if current version is at least that of what is passed.
+      # Will not work if apple ever does semantic versions like 8.2.1
+      # `rmq.device.ios_at_least? 8`
+      # `rmq.device.ios_at_least? 7.1`
+      #
+      # @return [Boolean]
+      def ios_at_least? version
+        version.to_f.round(3) <= ios_version.to_f.round(3)
+      end
+
       # @return [UIScreen]
       def screen
         UIScreen.mainScreen

--- a/spec/device.rb
+++ b/spec/device.rb
@@ -46,6 +46,15 @@ describe 'device' do
     rmq.device.is_version?(current_version[0]).should == true
   end
 
+  it 'lets you know if a minimum iOS version is in use' do
+    current_version = rmq.device.ios_version
+    rmq.device.ios_at_least?(current_version).should == true
+    # no one is using below iOS 2.1, so current version greater should always be true
+    rmq.device.ios_at_least?(2.1).should == true
+    # fail condition - hello person from the future!
+    rmq.device.ios_at_least?(999).should == false
+  end
+
   it 'should have a screen' do
     @rmq.device.screen.should == UIScreen.mainScreen
   end


### PR DESCRIPTION
This method allows you to future-proof your iOS checks by making sure you only run code if an iOS version is at least the minimum specified.

This is great for straddling ios versions, with dual functionality.
