### PR TITLE
Adds methods to apply shadows to UIViews

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_view_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_view_styler.rb
@@ -316,7 +316,26 @@ module RubyMotionQuery
       def alpha ; view.alpha ; end
       def alpha=(v) ; view.alpha = v ; end
 
+      def shadow_color=(c)
+        c = c.CGColor if c.kind_of?(UIColor)
+        @view.layer.shadowColor = c
+      end
+      def shadow_color ; @view.layer.shadowColor ; end
 
+      def shadow_offset=(offset)
+        @view.layer.shadowOffset = offset
+      end
+      def shadow_offset ; @view.layer.shadowOffset ; end
+
+      def shadow_opacity=(opacity)
+        @view.layer.shadowOpacity = opacity
+      end
+      def shadow_opacity ; @view.layer.shadowOpacity ; end
+
+      def shadow_path=(path)
+        @view.layer.shadowPath = path
+      end
+      def shadow_path ; @view.layer.shadowPath ; end
 
 
       # @deprecated - use frame hashs

--- a/spec/stylers/_ui_view_styler.rb
+++ b/spec/stylers/_ui_view_styler.rb
@@ -50,6 +50,12 @@ class SyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
     st.background_color = color.red
     st.tint_color = color.blue
     st.corner_radius = 5
+
+    # Shadows
+    st.shadow_color = color.gray
+    st.shadow_offset = CGSizeMake(0, 5)
+    st.shadow_opacity = 0.5
+    st.shadow_path = UIBezierPath.bezierPathWithRect(st.view.bounds).CGPath
   end
 end
 
@@ -318,5 +324,14 @@ describe 'ui_view_styler' do
     rmq(view).style { |st| @value = st.enabled }
 
     @value.should.be.false
+  end
+
+  it "should set shadow values" do
+    view = @vc.rmq.append(@view_klass, :ui_view_kitchen_sink).get
+
+    view.layer.shadowColor.should == rmq.color.gray.CGColor
+    view.layer.shadowOffset.should == CGSizeMake(0.0, 5.0)
+    view.layer.shadowOpacity.should == 0.5
+    view.layer.shadowPath.should == UIBezierPath.bezierPathWithRect(view.bounds).CGPath
   end
 end


### PR DESCRIPTION
Now you can create shadows easily!

```ruby
  def button_holder(st)
    st.frame = {
      h: 100,
      fb: 0,
      fl: 0,
      fr: 0
    }
    st.background_color = color.white

    shadow_path = UIBezierPath.bezierPathWithRect(st.view.bounds)
    st.masks_to_bounds = false # This is critical
    st.shadow_color = color.black
    st.shadow_offset = CGSizeMake(0, -2)
    st.shadow_opacity = 0.5
    st.shadow_path = shadow_path.CGPath
  end
```

Do you think that if they set a shadow property, we should set `st.masks_to_bounds = false` automatically?