### PR TITLE
Add delete tag feature

### DIFF
--- a/motion/ruby_motion_query/data.rb
+++ b/motion/ruby_motion_query/data.rb
@@ -37,6 +37,7 @@ module RubyMotionQuery
     #   rmq(my_view).untag(:foo, :bar)
     # Do nothing if no tag supplied or tag not present
     def untag(*tag_or_tags)
+      puts "untag method"
       tag_or_tags.each do |tag_name|
         tags.delete tag_name
       end

--- a/motion/ruby_motion_query/data.rb
+++ b/motion/ruby_motion_query/data.rb
@@ -37,8 +37,7 @@ module RubyMotionQuery
     #   rmq(my_view).untag(:foo, :bar)
     # Do nothing if no tag supplied or tag not present
     def untag(*tag_or_tags)
-      puts "untag method"
-      tag_or_tags.each do |tag_name|
+      tag_or_tags.flatten.each do |tag_name|
         tags.delete tag_name
       end
     end

--- a/motion/ruby_motion_query/data.rb
+++ b/motion/ruby_motion_query/data.rb
@@ -32,6 +32,16 @@ module RubyMotionQuery
       end
     end
 
+    # *Do not* use this, use {RMQ#untag} instead:
+    # @example
+    #   rmq(my_view).untag(:foo, :bar)
+    # Do nothing if no tag supplied or tag not present
+    def untag(*tag_or_tags)
+      tag_or_tags.each do |tag_name|
+        tags.delete tag_name
+      end
+    end
+
     # Check if this view contains a specific tag
     #
     # @param tag_name name of tag to check

--- a/motion/ruby_motion_query/tags.rb
+++ b/motion/ruby_motion_query/tags.rb
@@ -21,7 +21,10 @@ module RubyMotionQuery
     end
 
     def untag(*tag_or_tags)
-      puts "this it untag"
+      selected.each do |view|
+        view.rmq_data.untag(tag_or_tags)
+      end
+      self
     end
 
     # @return [RMQ]

--- a/motion/ruby_motion_query/tags.rb
+++ b/motion/ruby_motion_query/tags.rb
@@ -20,6 +20,10 @@ module RubyMotionQuery
       self
     end
 
+    def untag(*tag_or_tags)
+      puts "this it untag"
+    end
+
     # @return [RMQ]
     def clear_tags
       selected.each do |view|

--- a/spec/tags.rb
+++ b/spec/tags.rb
@@ -4,19 +4,34 @@ describe 'tags' do
     @root_view = @vc.view
   end
 
-  it 'should tag a view with a single tag' do
+  it 'should tag and untag a view with a single tag' do
     @vc.rmq.append(UIView).tap do |q|
       q.tag(:foo)
       q.get.rmq_data.tags.should.include :foo
       q.get.rmq_data.tags.should.not.include :bar
+      q.untag(:foo)
+      q.get.rmq_data.tags.should.not.include :foo
     end
   end
 
-  it 'should tag a view with a multiple tags' do
+  it 'should tag and untag a view with a multiple tags' do
     @vc.rmq.append(UIView).tap do |q|
       q.tag(:foo, :bar)
       q.get.rmq_data.tags.should.include :foo
       q.get.rmq_data.tags.should.include :bar
+      q.untag(:foo, :bar)
+      q.get.rmq_data.tags.should.not.include :foo
+      q.get.rmq_data.tags.should.not.include :bar
+    end
+  end
+
+  it 'should only untag if tag exists' do
+    @vc.rmq.append(UIView).tap do |q|
+      q.tag(:foo)
+      q.untag(:bar)
+      q.untag(:bar, :baz)
+      q.untag
+      q.get.rmq_data.tag_names.should == [:foo]
     end
   end
 


### PR DESCRIPTION
I love the tagging feature of RMQ, but needed to "unselect" a UIButton that I had tagged as "selected" (without removing other tags) and after a bit of digging around found that there was no wrapper for this similar to the handy 'tag' method (accessing hash directly seemed wrong). There are lots of ways of implementing but aiming for solution of "least surprise" (wanted to leave clear_tags alone). Hope it's okay, cheers Jay