### PR TITLE
Conforming color stylers

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_label_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_label_styler.rb
@@ -13,6 +13,8 @@ module RubyMotionQuery
 
       def color=(value) ; @view.setTextColor value ; end
       def color ; @view.textColor ; end
+      alias :text_color :color
+      alias :text_color= :color=
 
       def number_of_lines=(value)
         value = 0 if value == :unlimited

--- a/motion/ruby_motion_query/stylers/ui_text_field_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_text_field_styler.rb
@@ -25,6 +25,7 @@ module RubyMotionQuery
       def text_color ; view.textColor ; end
       def text_color=(v) ; view.textColor = v ; end
       alias :color :text_color
+      alias :color= :text_color=
 
       def text_alignment ; view.textAlignment ; end
       def text_alignment=(v) ; view.textAlignment = TEXT_ALIGNMENTS[v] || v ; end

--- a/spec/stylers/ui_label_styler.rb
+++ b/spec/stylers/ui_label_styler.rb
@@ -12,6 +12,10 @@ class SyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
     st.line_break_mode = NSLineBreakByWordWrapping
   end
 
+  def ui_label_color(st)
+    st.text_color = color.blue
+  end
+
   def ui_label_centered(st)
     ui_label_kitchen_sink(st)
     st.text_alignment = :centered
@@ -45,6 +49,11 @@ describe 'stylers/ui_label' do
       v.lineBreakMode.should == NSLineBreakByWordWrapping
     end
 
+  end
+
+  it 'allows color set with `text_color`' do
+    view = @vc.rmq.append!(@view_klass, :ui_label_color)
+    view.textColor.should == rmq.color.blue
   end
 
   it 'should use :centered as an alias for :center' do

--- a/spec/stylers/ui_text_field_styler.rb
+++ b/spec/stylers/ui_text_field_styler.rb
@@ -2,6 +2,7 @@ describe 'stylers/ui_text_field' do
   class SyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
     def ui_text_field_kitchen_sink(st)
       st.text = 'foo'
+      st.color = color.red
       st.text_alignment = :center
       st.placeholder = "placeholder"
       st.border_style = UITextBorderStyleRoundedRect
@@ -10,6 +11,10 @@ describe 'stylers/ui_text_field' do
       st.return_key_type = UIReturnKeyNext
       st.spell_checking_type = UITextSpellCheckingTypeYes
       st.right_view_mode = :always
+    end
+
+    def ui_text_field_color(st)
+      st.text_color = color.blue
     end
 
     def ui_text_field_email(st)
@@ -50,6 +55,7 @@ describe 'stylers/ui_text_field' do
 
     view.tap do |v|
       v.text.should == 'foo'
+      v.textColor.should == rmq.color.red
       v.textAlignment.should  == NSTextAlignmentCenter
       v.placeholder.should == "placeholder"
       v.borderStyle.should == UITextBorderStyleRoundedRect
@@ -59,6 +65,11 @@ describe 'stylers/ui_text_field' do
       v.spellCheckingType.should == UITextSpellCheckingTypeYes
       v.rightViewMode == UITextFieldViewModeAlways
     end
+  end
+
+  it 'allows color set with `text_color`' do
+    view = @vc.rmq.append!(@view_klass, :ui_text_field_color)
+    view.textColor.should == rmq.color.blue
   end
 
   it 'should allow setting a keyboard type via symbol' do

--- a/spec/stylers/ui_text_view_styler_spec.rb
+++ b/spec/stylers/ui_text_view_styler_spec.rb
@@ -2,12 +2,17 @@ describe 'stylers/ui_text_view' do
   class SyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
     def ui_text_view_kitchen_sink(st)
       st.text = 'foo'
+      st.color = color.red
       st.font = font.system(12)
       st.text_alignment = :center
       st.text_color = color.red
       st.editable = true
       st.selectable = true
       st.data_detector_types = :all
+    end
+
+    def ui_text_view_color(st)
+      st.text_color = color.blue
     end
 
     def ui_text_view_attributed_string(st)
@@ -28,6 +33,7 @@ describe 'stylers/ui_text_view' do
 
     view.tap do |v|
       view.text.should == "foo"
+      view.textColor.should == rmq.color.red
       view.font.should == UIFont.systemFontOfSize(12)
       view.textColor.should == UIColor.redColor
       view.textAlignment.should == NSTextAlignmentCenter
@@ -35,6 +41,11 @@ describe 'stylers/ui_text_view' do
       view.isSelectable.should == true
       view.dataDetectorTypes.should == UIDataDetectorTypeAll
     end
+  end
+
+  it 'allows color set with `text_color`' do
+    view = @vc.rmq.append!(@view_klass, :ui_text_view_color)
+    view.textColor.should == rmq.color.blue
   end
 
   it "applies an attributed string" do


### PR DESCRIPTION
Sometimes in UITextview, UILabel, and UITextField you could use `color=` and sometimes you had to use `text_color`.   Sometimes it was aliased, and sometimes it wasn't!

This makes all 3 use and respond to `text_color` and `color` stylers for setting `.textColor` on a view.