### PR TITLE
Allow setting keyboard_appearance with a symbol

### DIFF
--- a/motion/ruby_motion_query/stylers/protocols/ui_text_input_traits.rb
+++ b/motion/ruby_motion_query/stylers/protocols/ui_text_input_traits.rb
@@ -14,7 +14,7 @@ module RubyMotionQuery
         def enables_return_key_automatically=(v) ; view.enablesReturnKeyAutomatically = v ; end
 
         def keyboard_appearance ; view.keyboardAppearance ; end
-        def keyboard_appearance=(v) ; view.keyboardAppearance = v ; end
+        def keyboard_appearance=(v) ; view.keyboardAppearance = KEYBOARD_APPEARANCES[v] || v ; end
 
         def keyboard_type ; view.keyboardType ; end
         def keyboard_type=(v) ; view.setKeyboardType(KEYBOARD_TYPES[v] || v) ; end

--- a/motion/ruby_motion_query/stylers/ui_view_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_view_styler.rb
@@ -26,6 +26,13 @@ module RubyMotionQuery
       alphabet: UIKeyboardTypeASCIICapable
     }
 
+    KEYBOARD_APPEARANCES = {
+      default: UIKeyboardAppearanceDefault,
+      dark: UIKeyboardAppearanceDark,
+      light: UIKeyboardAppearanceLight,
+      alert: UIKeyboardAppearanceAlert
+    }
+
     RETURN_KEY_TYPES = {
       default: UIReturnKeyDefault,
       go: UIReturnKeyGo,

--- a/spec/stylers/ui_text_field_styler.rb
+++ b/spec/stylers/ui_text_field_styler.rb
@@ -9,6 +9,7 @@ describe 'stylers/ui_text_field' do
       st.autocapitalization_type = :words
       st.autocorrection_type = :no
       st.keyboard_type = UIKeyboardTypeDefault
+      st.keyboard_appearance = UIKeyboardAppearanceDark
       st.return_key_type = UIReturnKeyNext
       st.spell_checking_type = UITextSpellCheckingTypeYes
       st.right_view_mode = :always
@@ -20,6 +21,10 @@ describe 'stylers/ui_text_field' do
 
     def ui_text_field_email(st)
       st.keyboard_type = :email_address
+    end
+
+    def ui_text_field_alert(st)
+      st.keyboard_appearance = :alert
     end
 
     def ui_text_field_google(st)
@@ -63,6 +68,7 @@ describe 'stylers/ui_text_field' do
       v.autocapitalizationType.should == UITextAutocapitalizationTypeWords
       v.autocorrectionType == UITextAutocorrectionTypeNo
       v.keyboardType.should == UIKeyboardTypeDefault
+      v.keyboardAppearance.should == UIKeyboardAppearanceDark
       v.returnKeyType.should == UIReturnKeyNext
       v.spellCheckingType.should == UITextSpellCheckingTypeYes
       v.rightViewMode == UITextFieldViewModeAlways
@@ -77,6 +83,11 @@ describe 'stylers/ui_text_field' do
   it 'should allow setting a keyboard type via symbol' do
     view = @vc.rmq.append(@view_klass, :ui_text_field_email).get
     view.keyboardType.should == UIKeyboardTypeEmailAddress
+  end
+
+  it 'should allow setting a keyboard appearance via symbol' do
+    view = @vc.rmq.append(@view_klass, :ui_text_field_alert).get
+    view.keyboardAppearance.should == UIKeyboardAppearanceAlert
   end
 
   it 'should allow setting a return key via symbol' do


### PR DESCRIPTION
`:default`
`:dark`
`:light`
`:alert`

![lert_zps8805e45d](https://cloud.githubusercontent.com/assets/139261/6316010/faad268a-b9d9-11e4-8e96-e832bdcf0553.jpg)
