### PR TITLE
New segment styler

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_segmented_control_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_segmented_control_styler.rb
@@ -8,7 +8,7 @@ module RubyMotionQuery
             @view.insertSegmentWithTitle(title, atIndex:index, animated:false)
           end
         elsif value.class == String
-          @view.insertSegmentWithTitle(title, atIndex:index, animated:false)
+          @view.insertSegmentWithTitle(value, atIndex:0, animated:false)
         else
           raise "#{__method__} takes an array or string."
         end

--- a/motion/ruby_motion_query/stylers/ui_segmented_control_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_segmented_control_styler.rb
@@ -1,8 +1,20 @@
 module RubyMotionQuery
   module Stylers
+    class UISegmentedControlStyler < UIControlStyler
 
-    class UISegmentedControlStyler < UIControlStyler 
+      def prepend_segments=(value)
+        if value.class == Array
+          value.each_with_index do |title, index|
+            @view.insertSegmentWithTitle(title, atIndex:index, animated:false)
+          end
+        elsif value.class == String
+          @view.insertSegmentWithTitle(title, atIndex:index, animated:false)
+        else
+          raise "#{__method__} takes an array or string."
+        end
+      end
+      alias :unshift= :prepend_segments=
+
     end
-
   end
 end

--- a/spec/stylers/ui_segmented_control_styler.rb
+++ b/spec/stylers/ui_segmented_control_styler.rb
@@ -1,6 +1,7 @@
 class StyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
 
   def ui_segment_kitchen_sink(st)
+    st.prepend_segments = 'Three'
     st.prepend_segments = ['One', 'Two']
   end
 
@@ -21,6 +22,7 @@ describe 'stylers/ui_segmented_control' do
     view.tap do |v|
       v.titleForSegmentAtIndex(0).should == "One"
       v.titleForSegmentAtIndex(1).should == "Two"
+      v.titleForSegmentAtIndex(2).should == "Three"
     end
   end
 end

--- a/spec/stylers/ui_segmented_control_styler.rb
+++ b/spec/stylers/ui_segmented_control_styler.rb
@@ -1,0 +1,26 @@
+class StyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
+
+  def ui_segment_kitchen_sink(st)
+    st.prepend_segments = ['One', 'Two']
+  end
+
+end
+
+describe 'stylers/ui_segmented_control' do
+  before do
+    @vc = UIViewController.alloc.init
+    @vc.rmq.stylesheet = StyleSheetForUIViewStylerTests
+    @view_klass = UISegmentedControl
+  end
+
+  behaves_like "styler"
+
+  it 'should apply a style with every UISegmentedControlStyler wrapper method' do
+    view = @vc.rmq.append(@view_klass, :ui_segment_kitchen_sink).get
+
+    view.tap do |v|
+      v.titleForSegmentAtIndex(0).should == "One"
+      v.titleForSegmentAtIndex(1).should == "Two"
+    end
+  end
+end


### PR DESCRIPTION
ability to set segments in rmq stylesheet.

```ruby
  def some_segment st
    st.frame = {l: 35, t: 80, w: 250, h: 25}
    st.prepend_segments = ['Button1 ', 'Button 2']
  end
```
