### PR TITLE
fix for iPhone 5 pointers

### DIFF
--- a/motion/ruby_motion_query/color.rb
+++ b/motion/ruby_motion_query/color.rb
@@ -161,8 +161,13 @@ module RubyMotionQuery
 
     def self.from_base_color(values)
       base = values[:base] || values[:color]
-      r, g, b, a = Pointer.new('d'), Pointer.new('d'), Pointer.new('d'), Pointer.new('d')
-      base.getRed(r, green: g, blue: b, alpha: a)
+      begin
+        r, g, b, a = Pointer.new('d'), Pointer.new('d'), Pointer.new('d'), Pointer.new('d')
+        base.getRed(r, green: g, blue: b, alpha: a)
+      rescue
+        r, g, b, a = Pointer.new('f'), Pointer.new('f'), Pointer.new('f'), Pointer.new('f')
+        base.getRed(r, green: g, blue: b, alpha: a)
+      end
 
       r = values[:r] || values[:red] || r.value
       g = values[:g] || values[:green] || g.value


### PR DESCRIPTION
currently spec fails for iPhone 5 `rake spec device_name="iPhone 5"`   Color causes crashes on iPhone 5!

This fixes that.