### PR TITLE
alias for text_align instead of text_alignment (for us web folk)

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_label_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_label_styler.rb
@@ -41,6 +41,8 @@ module RubyMotionQuery
       def text_alignment
         @view.textAlignment
       end
+      alias :text_align= :text_alignment=
+      alias :text_align :text_alignment
 
       def resize_to_fit_text
         @view.sizeToFit

--- a/spec/stylers/ui_label_styler.rb
+++ b/spec/stylers/ui_label_styler.rb
@@ -23,7 +23,7 @@ class StyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
 
   def ui_label_text_align(st)
     ui_label_kitchen_sink(st)
-    st.text_align = :left
+    st.text_align = :right
   end
 
   def ui_label_attributed_string(st)
@@ -73,7 +73,7 @@ describe 'stylers/ui_label' do
     view = @vc.rmq.append(@view_klass, :ui_label_text_align).get
 
     view.tap do |v|
-      v.textAlignment.should == NSTextAlignmentLeft
+      v.textAlignment.should == NSTextAlignmentRight
     end
   end
 

--- a/spec/stylers/ui_label_styler.rb
+++ b/spec/stylers/ui_label_styler.rb
@@ -21,6 +21,11 @@ class StyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
     st.text_alignment = :centered
   end
 
+  def ui_label_text_align(st)
+    ui_label_kitchen_sink(st)
+    st.text_align = :left
+  end
+
   def ui_label_attributed_string(st)
     st.attributed_text = NSAttributedString.alloc.initWithString("RMQ")
   end
@@ -61,6 +66,14 @@ describe 'stylers/ui_label' do
 
     view.tap do |v|
       v.textAlignment.should == NSTextAlignmentCenter
+    end
+  end
+
+  it 'should use text_align as an alias for ui_label_text_align' do
+    view = @vc.rmq.append(@view_klass, :ui_label_text_align).get
+
+    view.tap do |v|
+      v.textAlignment.should == NSTextAlignmentLeft
     end
   end
 


### PR DESCRIPTION
Keep making this mistake so I figure it's a good alias.

