### PR TITLE
Added convenience callback block after append, build, etc, and find_or_append() (with tests)

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -102,7 +102,7 @@ class MainController < UIViewController
 
   def init_popup_section
 
-    rmq.append(UIView, :popup_section).tap do |q|
+    rmq.append(UIView, :popup_section) do |q|
 
       @title_label = q.append!(UILabel, :title_label)
       q.append(UIButton, :open_popup).on(:touch_down) do |sender|
@@ -116,7 +116,7 @@ class MainController < UIViewController
 
       end.on(:touch_up) do |sender|
 
-        rmq.append(UILabel, :popup_wrapper).tap do |o|
+        rmq.append(UILabel, :popup_wrapper) do |o|
           o.animations.fade_in
           o.append(UILabel, :popup_text_label)
         end
@@ -132,7 +132,7 @@ class MainController < UIViewController
   def init_validation_section
 
     # let's lay this out using the grid!
-    rmq.append(UIView, :validation_section).tap do |q|
+    rmq.append(UIView, :validation_section) do |q|
       q.append(UILabel, :validation_title)
       @digits_only = q.append(UITextField, :only_digits).validates(:digits).on(:change) do |sender|
         rmq(sender).valid?

--- a/motion/ruby_motion_query/stylesheet.rb
+++ b/motion/ruby_motion_query/stylesheet.rb
@@ -145,7 +145,7 @@ module RubyMotionQuery
         view.rmq_style_applied
       rescue NoMethodError => e
         if e.message =~ /.*#{style_name.to_s}.*/
-          puts "\n[RMQ ERROR]  style_name :#{style_name} doesn't exist for a #{view.class.name}. Add 'def #{style_name}(st)' to #{stylesheet.class.name} class\n\n"
+          $stderr.puts "\n[RMQ ERROR]  style_name :#{style_name} doesn't exist for a #{view.class.name}. Add 'def #{style_name}(st)' to #{stylesheet.class.name} class\n\n"
         else
           raise e
         end

--- a/motion/ruby_motion_query/subviews.rb
+++ b/motion/ruby_motion_query/subviews.rb
@@ -19,7 +19,6 @@ module RubyMotionQuery
     # @return [RMQ]
     def add_subview(view_or_constant, opts={})
       subviews_added = []
-      style = opts[:style]
 
       selected.each do |selected_view|
         created = false
@@ -63,11 +62,14 @@ module RubyMotionQuery
         new_view.rmq_appended if appended
 
         if self.stylesheet
-          apply_style_to_view(new_view, style) if style
+          apply_style_to_view(new_view, opts[:style]) if opts[:style]
         end
       end
 
-      RMQ.create_with_array_and_selectors(subviews_added, selectors, @context, self)
+      view = RMQ.create_with_array_and_selectors(subviews_added, selectors, @context, self)
+      opts[:block].call view if opts[:block]
+      opts[:raw_block].call view.get if opts[:raw_block]
+      view
     end
     alias :insert :add_subview
 
@@ -93,8 +95,9 @@ module RubyMotionQuery
     #   rmq.append(UIImageView)
     #
     # @return [RMQ]
-    def append(view_or_constant, style=nil, opts = {})
+    def append(view_or_constant, style=nil, opts = {}, &block)
       opts[:style] = style
+      opts[:block] = block if block
       add_subview(view_or_constant, opts)
     end
 
@@ -103,16 +106,18 @@ module RubyMotionQuery
     # @example
     #   @my_button = rmq.append! UIButton
     #   @my_label = rmq.append!(UILabel, :my_label)
-    def append!(view_or_constant, style=nil, opts = {})
+    def append!(view_or_constant, style=nil, opts = {}, &block)
+      opts[:raw_block] = block if block
       append(view_or_constant, style, opts).get
     end
 
     # Just like append, but inserts the view at index 0 of the subview array
     #
     # @return [RMQ]
-    def unshift(view_or_constant, style=nil, opts = {})
+    def unshift(view_or_constant, style=nil, opts = {}, &block)
       opts[:at_index] = 0
       opts[:style] = style
+      opts[:block] = block if block
       add_subview view_or_constant, opts
     end
     alias :prepend :unshift
@@ -122,7 +127,8 @@ module RubyMotionQuery
     # @example
     #   @my_button = rmq.prepend! UIButton
     #   @my_label = rmq.prepend!(UILabel, :my_label)
-    def unshift!(view_or_constant, style=nil, opts = {})
+    def unshift!(view_or_constant, style=nil, opts = {}, &block)
+      opts[:raw_block] = block if block
       unshift(view_or_constant, style, opts).get
     end
     alias :prepend! :unshift!
@@ -147,10 +153,11 @@ module RubyMotionQuery
     #     end
     #   end
     #
-    def create(view_or_constant, style = nil, opts = {})
+    def create(view_or_constant, style = nil, opts = {}, &block)
       # TODO, refactor so that add_subview uses create, not backwards like it is now
       opts[:do_not_add] = true
       opts[:style] = style
+      opts[:block] = block if block
       add_subview view_or_constant, opts
     end
 
@@ -158,7 +165,8 @@ module RubyMotionQuery
     #
     # @example
     #   @my_button = rmq.create! UIButton
-    def create!(view_or_constant, style=nil, opts = {})
+    def create!(view_or_constant, style=nil, opts = {}, &block)
+      opts[:raw_block] = block if block
       create(view_or_constant, style, opts).get
     end
 
@@ -174,9 +182,10 @@ module RubyMotionQuery
     # def rmq_build
     #   rmq.append(UIView, :foo)
     # end
-    def build(view, style = nil, opts = {})
+    def build(view, style = nil, opts = {}, &block)
       opts[:do_not_add] = true
       opts[:style] = style
+      opts[:block] = block if block
       add_subview view, opts
     end
 
@@ -184,7 +193,8 @@ module RubyMotionQuery
     #
     # @example
     #   @my_cell = rmq.build! cell
-    def build!(view, style = nil, opts = {})
+    def build!(view, style = nil, opts = {}, &block)
+      opts[:raw_block] = block if block
       build(view, style, opts).get
     end
 

--- a/motion/ruby_motion_query/subviews.rb
+++ b/motion/ruby_motion_query/subviews.rb
@@ -119,12 +119,10 @@ module RubyMotionQuery
     #   @my_button = rmq.find_or_append(UIButton, :my_button) # Only one created
     def find_or_append(view_or_constant, style=nil, opts = {}, &block)
       if style && (q = self.find(style)) && q.length > 0
-        q.reapply_styles
-        block.call q if block
-        q
-      else
-        append(view_or_constant, style, opts, &block)
+        view_or_constant = q.get
       end
+
+      append(view_or_constant, style, opts, &block)
     end
 
     # Same as append!, but will look for a view with the same name and reapply styles
@@ -134,9 +132,7 @@ module RubyMotionQuery
     #   @my_button = rmq.find_or_append!(UIButton, :my_button)
     #   @my_button = rmq.find_or_append!(UIButton, :my_button) # Only one created
     def find_or_append!(view_or_constant, style=nil, opts = {}, &block)
-      find_or_append(view_or_constant, style, opts).get.tap do |q|
-        block.call q
-      end
+      find_or_append(view_or_constant, style, opts, &block).get
     end
 
     # Just like append, but inserts the view at index 0 of the subview array

--- a/motion/ruby_motion_query/subviews.rb
+++ b/motion/ruby_motion_query/subviews.rb
@@ -111,6 +111,34 @@ module RubyMotionQuery
       append(view_or_constant, style, opts).get
     end
 
+    # Same as append, but will look for a view with the same name and reapply styles
+    # to it if it finds one. If it doesn't, it'll append as normal.
+    #
+    # @example
+    #   @my_button = rmq.find_or_append(UIButton, :my_button)
+    #   @my_button = rmq.find_or_append(UIButton, :my_button) # Only one created
+    def find_or_append(view_or_constant, style=nil, opts = {}, &block)
+      if style && (q = self.find(style)) && q.length > 0
+        q.reapply_styles
+        block.call q if block
+        q
+      else
+        append(view_or_constant, style, opts, &block)
+      end
+    end
+
+    # Same as append!, but will look for a view with the same name and reapply styles
+    # to it if it finds one. If it doesn't, it'll append! as normal.
+    #
+    # @example
+    #   @my_button = rmq.find_or_append!(UIButton, :my_button)
+    #   @my_button = rmq.find_or_append!(UIButton, :my_button) # Only one created
+    def find_or_append!(view_or_constant, style=nil, opts = {}, &block)
+      find_or_append(view_or_constant, style, opts).get.tap do |q|
+        block.call q
+      end
+    end
+
     # Just like append, but inserts the view at index 0 of the subview array
     #
     # @return [RMQ]

--- a/spec/subviews.rb
+++ b/spec/subviews.rb
@@ -334,6 +334,44 @@ describe 'subviews' do
       block_called.should == true
     end
   end
+
+  describe 'find_or_append' do
+    it 'appends if none existing' do
+      @vc.view.subviews.length.should == 0
+      view = @vc.rmq.find_or_append(UIView).get
+      @vc.view.subviews.length.should == 1
+      @vc.view.subviews.first.should == view
+    end
+
+    it 'finds if existing' do
+      @vc.rmq.stylesheet = StyleSheetForSubviewsTests
+      @vc.view.subviews.length.should == 0
+      existing_view = @vc.rmq.append(UIView, :my_style).get
+      @vc.view.subviews.length.should == 1
+      found_view = @vc.rmq.find_or_append(UIView, :my_style).get
+      @vc.view.subviews.length.should == 1
+      found_view.should == existing_view
+    end
+  end
+
+  describe 'find_or_append!' do
+    it 'appends if none existing' do
+      @vc.view.subviews.length.should == 0
+      view = @vc.rmq.find_or_append!(UIView)
+      @vc.view.subviews.length.should == 1
+      @vc.view.subviews.first.should == view
+    end
+
+    it 'finds if existing' do
+      @vc.rmq.stylesheet = StyleSheetForSubviewsTests
+      @vc.view.subviews.length.should == 0
+      existing_view = @vc.rmq.append!(UIView, :my_style)
+      @vc.view.subviews.length.should == 1
+      found_view = @vc.rmq.find_or_append!(UIView, :my_style)
+      @vc.view.subviews.length.should == 1
+      found_view.should == existing_view
+    end
+  end
 end
 
 class StyleSheetForSubviewsTests < RubyMotionQuery::Stylesheet

--- a/spec/subviews.rb
+++ b/spec/subviews.rb
@@ -15,7 +15,7 @@ describe 'subviews' do
     @vc.view.subviews.first.should == view
   end
 
-  it 'should addend to the end of the subviews' do
+  it 'should append to the end of the subviews' do
     view = @vc.rmq.append(UIView).get
     @vc.view.subviews[@vc.view.subviews.length - 1].should == view
   end
@@ -138,6 +138,25 @@ describe 'subviews' do
     #TODO
   end
 
+  it 'should insert then yield to a block with the rmq object' do
+    block_called = false
+    @vc.rmq.append(UILabel) do |view|
+      view.should.be.kind_of(RubyMotionQuery::RMQ)
+      view.get.should.be.kind_of(UILabel)
+      block_called = true
+    end
+    block_called.should == true
+  end
+
+  it 'should insert then yield to a block with the created view' do
+    block_called = false
+    @vc.rmq.append!(UILabel) do |view|
+      view.should.be.kind_of(UILabel)
+      block_called = true
+    end
+    block_called.should == true
+  end
+
   describe 'create' do
     it 'should allow you to create a view using rmq, without appending it to the view tree' do
       test_view_wrapped = @vc.rmq.create(SubviewTestView)
@@ -203,6 +222,26 @@ describe 'subviews' do
       table_sub.class.should == SubTableTest
       table_sub.style.should == UITableViewStyleGrouped
     end
+
+    it 'should create then yield to a block with the rmq object' do
+      block_called = false
+      @vc.rmq.create(UILabel) do |view|
+        view.should.be.kind_of(RubyMotionQuery::RMQ)
+        view.get.should.be.kind_of(UILabel)
+        block_called = true
+      end
+      block_called.should == true
+    end
+
+    it 'should create then yield to a block with the created view' do
+      block_called = false
+      @vc.rmq.create!(UILabel) do |view|
+        view.should.be.kind_of(UILabel)
+        block_called = true
+      end
+      block_called.should == true
+    end
+
   end
 
   describe 'build' do
@@ -272,6 +311,27 @@ describe 'subviews' do
 
       @vc.rmq.append(view)
       view.number_of_builds.should == 1
+    end
+
+    it 'should build an existing view then yield to a block with the rmq wrapped view' do
+      existing_view = UIView.new
+      block_called = false
+      @vc.rmq.build(existing_view) do |view|
+        view.should.be.kind_of(RubyMotionQuery::RMQ)
+        view.get.should == existing_view
+        block_called = true
+      end
+      block_called.should == true
+    end
+
+    it 'should build an existing view then yield to a block with the existing view' do
+      existing_view = UIView.new
+      block_called = false
+      @vc.rmq.build!(existing_view) do |view|
+        view.should == existing_view
+        block_called = true
+      end
+      block_called.should == true
     end
   end
 end

--- a/spec/traversing.rb
+++ b/spec/traversing.rb
@@ -1,4 +1,4 @@
-describe 'transversing' do
+describe 'traversing' do
   before do
     @vc = UIViewController.alloc.init
     @root_view = @vc.view


### PR DESCRIPTION
We find ourselves doing a lot of `.tap do |view|` when we're doing layout:

```ruby
append(UIView, :wrapper).tap do |wrapper|
  wrapper.append(UIView, :something).tap do |something|
    something.append(UILabel, :label).data("Hi!")
  end
end
```

This lets you do:

```ruby
append UIView, :wrapper do |wrapper|
  wrapper.append UIView, :something do |something|
    something.append(UILabel, :label).data("Hi!")
  end
end
```

Specs passing locally.

Also added `find_or_append` and `find_or_append!` which do what you think they do.

```ruby
rmq(self.view).find_or_append(UIView, :my_view) # added only if it isn't already in `self.view` somewhere.
```
