### PR TITLE
Don't stop looking for the view controller when it's a UINavigationController

### DIFF
--- a/motion/ruby_motion_query/app.rb
+++ b/motion/ruby_motion_query/app.rb
@@ -118,7 +118,7 @@ module RubyMotionQuery
         if root_view_controller || ((window = RMQ.app.window) && (root_view_controller = window.rootViewController))
           case root_view_controller
           when UINavigationController
-            root_view_controller.visibleViewController
+            current_view_controller(root_view_controller.visibleViewController)
           when UITabBarController
             current_view_controller(root_view_controller.selectedViewController)
           else


### PR DESCRIPTION
I needed to put a `UITabBarController` inside a `UINavigationController` (I know, NOT recommended by Apple, but I had to do it nonetheless).

This fixes the stylesheet not being able to be set because when it found a `UINavigationController` as the `root_view_controller`, it just gave up. I'm asking the method to keep searching till it gets an actual `UIViewController` and not blindly trust that the `visibleViewController` is a `UIViewController`.

An alternative so that we don't have to recurse one more time would be something like this:

```ruby
when UINavigationController
  if root_view_controller.visibleViewController.is_a?(UIViewController)
    root_view_controller.visibleViewController
  else
    current_view_controller(root_view_controller.visibleViewController)
  end
when UITabBarController
# ...
```