### PR TITLE
Add init_with_segments to UISegmentedControlStyler

### DIFF
--- a/motion/ruby_motion_query/stylers/ui_segmented_control_styler.rb
+++ b/motion/ruby_motion_query/stylers/ui_segmented_control_styler.rb
@@ -15,6 +15,10 @@ module RubyMotionQuery
       end
       alias :unshift= :prepend_segments=
 
+      def init_with_segments=(value)
+        self.prepend_segments = value unless view_has_been_styled?
+      end
+      
     end
   end
 end

--- a/spec/stylers/ui_segmented_control_styler.rb
+++ b/spec/stylers/ui_segmented_control_styler.rb
@@ -1,6 +1,7 @@
 class StyleSheetForUIViewStylerTests < RubyMotionQuery::Stylesheet
 
   def ui_segment_kitchen_sink(st)
+    st.init_with_segments = ['Four','Five']
     st.prepend_segments = 'Three'
     st.prepend_segments = ['One', 'Two']
   end
@@ -23,6 +24,8 @@ describe 'stylers/ui_segmented_control' do
       v.titleForSegmentAtIndex(0).should == "One"
       v.titleForSegmentAtIndex(1).should == "Two"
       v.titleForSegmentAtIndex(2).should == "Three"
+      v.titleForSegmentAtIndex(3).should == "Four"
+      v.titleForSegmentAtIndex(4).should == "Five"
     end
   end
 end


### PR DESCRIPTION
Not sure if this makes total sense for everyone. I was using ```live_stylesheets``` on a view with a UISegmentedControl, and at every reload the initial segments I had set were repeating and number of segments were growing. It took me a few minutes to realize that ```prepend_segments``` meant just that, and every time the stylesheet were replied, more segments were prepended. 

Of course one could use ```unless st.view_has_been_styled?``` in their stylesheets, instead of having e specific method for this.

Cheers!