### PR TITLE
Adds rmq.tags interface

### DIFF
--- a/motion/ruby_motion_query/tags.rb
+++ b/motion/ruby_motion_query/tags.rb
@@ -49,6 +49,26 @@ module RubyMotionQuery
       false # tag doesn't exist if we got here
     end
 
+    def tags(key=nil)
+      tags = {}
+      selected.each do |view|
+        view.rmq_data.tags.each do |tag, data|
+          tags[tag] ||= []
+          tags[tag] << data
+        end
+      end
+      tags = tags.inject({}) do |hash,(k,v)|
+        hash[k] = v.length == 1 ? v.first : v
+        hash
+      end
+
+      if key
+        tags[key]
+      else
+        tags
+      end
+    end
+
     # See /motion/data.rb for the rest of the tag stuff
 
   end

--- a/spec/tags.rb
+++ b/spec/tags.rb
@@ -74,4 +74,22 @@ describe 'tags' do
     end
   end
 
+  it 'should return the tags for the selection' do
+    @vc.rmq.append(UIView).tag(data: "some-data")
+    @vc.rmq.append(UIView).tag(other_data: "other-data")
+    @vc.rmq.all.tags.should == { data: "some-data", other_data: "other-data" }
+  end
+
+  it 'should be able to return tag data' do
+    @vc.rmq.append(UIView).tag(data: "some-data").tap do |q|
+      q.tags(:data).should == "some-data"
+    end
+  end
+
+  it 'should return an array of data if there are duplicate tags in the selection' do
+    @vc.rmq.append(UIView).tag(data: "some-data")
+    @vc.rmq.append(UIView).tag(data: "other-data")
+    @vc.rmq.all.tags(:data).should == ["some-data", "other-data"]
+  end
+
 end


### PR DESCRIPTION
  * rmq.all.tags => hash of tag data
  * rmq.all.tags(:stuff) => all data in :stuff tag for selected views

This adds the convenience methods that we talked about having in #228
