### PR TITLE
Fix #285

### DIFF
--- a/motion/ruby_motion_query/app.rb
+++ b/motion/ruby_motion_query/app.rb
@@ -120,20 +120,31 @@ module RubyMotionQuery
       # @return [UIViewController]
       def current_view_controller(root_view_controller = nil)
         if root_view_controller || ((window = RMQ.app.window) && (root_view_controller = window.rootViewController))
-          if root_view_controller.respond_to?(:visibleViewController)
-            current_view_controller(root_view_controller.visibleViewController) # UINavigationController
-          elsif root_view_controller.respond_to?(:topViewController)
-            current_view_controller(root_view_controller.topViewController)
-          elsif root_view_controller.respond_to?(:frontViewController)
-            current_view_controller(root_view_controller.frontViewController)
-          elsif root_view_controller.respond_to?(:center) && (center = root_view_controller.center) && center.is_a?(UIViewController)
-            current_view_controller(root_view_controller.center)
-          elsif root_view_controller.respond_to?(:childViewControllers) && root_view_controller.childViewControllers.count > 0
-            current_view_controller(root_view_controller.childViewControllers.first)
-          elsif root_view_controller.respond_to?(:selectedViewController) && root_view_controller.viewControllers.count > 0
-            current_view_controller(root_view_controller.selectedViewController) # UITabBarController
+          case root_view_controller
+          when UIMoreNavigationController # This must be above UINavigationController becuase it's a subclass
+            root_view_controller.visibleViewController
+          when UINavigationController
+            current_view_controller(root_view_controller.visibleViewController)
+          when UITabBarController
+            if root_view_controller.viewControllers.count > 5 && root_view_controller.selectedIndex >= 4
+              current_view_controller(root_view_controller.moreNavigationController)
+            else
+              current_view_controller(root_view_controller.selectedViewController)
+            end
           else
-            root_view_controller
+            if root_view_controller.respond_to?(:visibleViewController)
+              current_view_controller(root_view_controller.visibleViewController)
+            elsif root_view_controller.respond_to?(:topViewController)
+              current_view_controller(root_view_controller.topViewController)
+            elsif root_view_controller.respond_to?(:frontViewController)
+              current_view_controller(root_view_controller.frontViewController)
+            elsif root_view_controller.respond_to?(:center) && (center = root_view_controller.center) && center.is_a?(UIViewController)
+              current_view_controller(root_view_controller.center)
+            elsif root_view_controller.respond_to?(:childViewControllers) && root_view_controller.childViewControllers.count > 0
+              current_view_controller(root_view_controller.childViewControllers.first)
+            else
+              root_view_controller
+            end
           end
         end
       end

--- a/motion/ruby_motion_query/app.rb
+++ b/motion/ruby_motion_query/app.rb
@@ -120,25 +120,20 @@ module RubyMotionQuery
       # @return [UIViewController]
       def current_view_controller(root_view_controller = nil)
         if root_view_controller || ((window = RMQ.app.window) && (root_view_controller = window.rootViewController))
-          case root_view_controller
-          when UINavigationController
-            current_view_controller(root_view_controller.visibleViewController)
-          when UITabBarController
-            current_view_controller(root_view_controller.selectedViewController)
+          if root_view_controller.respond_to?(:visibleViewController)
+            current_view_controller(root_view_controller.visibleViewController) # UINavigationController
+          elsif root_view_controller.respond_to?(:topViewController)
+            current_view_controller(root_view_controller.topViewController)
+          elsif root_view_controller.respond_to?(:frontViewController)
+            current_view_controller(root_view_controller.frontViewController)
+          elsif root_view_controller.respond_to?(:center) && (center = root_view_controller.center) && center.is_a?(UIViewController)
+            current_view_controller(root_view_controller.center)
+          elsif root_view_controller.respond_to?(:childViewControllers) && root_view_controller.childViewControllers.count > 0
+            current_view_controller(root_view_controller.childViewControllers.first)
+          elsif root_view_controller.respond_to?(:selectedViewController) && root_view_controller.viewControllers.count > 0
+            current_view_controller(root_view_controller.selectedViewController) # UITabBarController
           else
-            if root_view_controller.respond_to?(:visibleViewController)
-              current_view_controller(root_view_controller.visibleViewController)
-            elsif root_view_controller.respond_to?(:topViewController)
-              current_view_controller(root_view_controller.topViewController)
-            elsif root_view_controller.respond_to?(:frontViewController)
-              current_view_controller(root_view_controller.frontViewController)
-            elsif root_view_controller.respond_to?(:center) && (center = root_view_controller.center) && center.is_a?(UIViewController)
-              current_view_controller(root_view_controller.center)
-            elsif root_view_controller.respond_to?(:childViewControllers) && root_view_controller.childViewControllers.count > 0
-              current_view_controller(root_view_controller.childViewControllers.first)
-            else
-              root_view_controller
-            end
+            root_view_controller
           end
         end
       end

--- a/spec/app.rb
+++ b/spec/app.rb
@@ -134,6 +134,88 @@ describe 'app' do
       rmq.app.window.rootViewController = old_root
     end
 
+    it 'should return current_view_controller when root controller is UITabController with multiple controllers and a more tab' do
+      tabbar = UITabBarController.alloc.init
+
+      new_controller_0 = UIViewController.new
+      new_controller_1 = UIViewController.new
+      new_controller_2 = UIViewController.new
+      new_controller_3 = UIViewController.new
+      new_controller_4 = UIViewController.new
+      new_controller_5 = UIViewController.new
+      new_controller_6 = UIViewController.new
+      tabbar.viewControllers = [
+        new_controller_0,
+        new_controller_1,
+        UINavigationController.alloc.initWithRootViewController(new_controller_2),
+        new_controller_3,
+        new_controller_4,
+        new_controller_5,
+        UINavigationController.alloc.initWithRootViewController(new_controller_6)
+      ]
+
+      old_root = rmq.app.window.rootViewController
+      rmq.app.window.rootViewController = tabbar
+
+      # Test regular tab indexes
+      tabbar.setSelectedIndex(0)
+      rmq.app.current_view_controller.should == new_controller_0
+      tabbar.setSelectedIndex(2)
+      rmq.app.current_view_controller.should == new_controller_2
+
+      # Test a view controller in the more nav controller
+      tabbar.setSelectedIndex(5)
+      rmq.app.current_view_controller.should == new_controller_5
+
+      # Test a view controller inside a nav controller in the more nav controller
+      tabbar.setSelectedIndex(6)
+      rmq.app.current_view_controller.should == new_controller_6
+
+      rmq.app.window.rootViewController = old_root
+    end
+
+    it 'should return current_view_controller when root controller is UITabController with multiple controllers contained inside a UINavigationController' do
+      tabbar = UITabBarController.alloc.init
+
+      new_controller_0 = UIViewController.new
+      new_controller_1 = UIViewController.new
+      new_controller_2 = UIViewController.new
+      new_controller_3 = UIViewController.new
+      new_controller_4 = UIViewController.new
+      new_controller_5 = UIViewController.new
+      new_controller_6 = UIViewController.new
+      tabbar.viewControllers = [
+        new_controller_0,
+        new_controller_1,
+        UINavigationController.alloc.initWithRootViewController(new_controller_2),
+        new_controller_3,
+        new_controller_4,
+        new_controller_5,
+        UINavigationController.alloc.initWithRootViewController(new_controller_6)
+      ]
+      nav_controller = UINavigationController.alloc.initWithRootViewController(tabbar)
+      nav_controller.setNavigationBarHidden(true)
+
+      old_root = rmq.app.window.rootViewController
+      rmq.app.window.rootViewController = nav_controller
+
+      # Test regular tab indexes
+      tabbar.setSelectedIndex(0)
+      rmq.app.current_view_controller.should == new_controller_0
+      tabbar.setSelectedIndex(2)
+      rmq.app.current_view_controller.should == new_controller_2
+
+      # Test a view controller in the more nav controller
+      tabbar.setSelectedIndex(5)
+      rmq.app.current_view_controller.should == new_controller_5
+
+      # Test a view controller inside a nav controller in the more nav controller
+      tabbar.setSelectedIndex(6)
+      rmq.app.current_view_controller.should == new_controller_6
+
+      rmq.app.window.rootViewController = old_root
+    end
+
     it 'should return current_view_controller when root controller is container controller with a topViewController method' do
       controller = MyTopViewController.alloc.init
       new_controller = UIViewController.new


### PR DESCRIPTION
Basically, if there's more than 5 tabs in the UITabBarController and the selected index is >=4 we need to use the UIMoreNavigationController to determine the correct value instead of using `selectedViewController` on the tab bar. What a hassle.

Closes #285 