### PR TITLE
ability to read `data` on rmq(UISwitch)

### DIFF
--- a/motion/ruby_motion_query/actions.rb
+++ b/motion/ruby_motion_query/actions.rb
@@ -51,7 +51,7 @@ module RubyMotionQuery
           when UIButton             then view.titleForState(UIControlStateNormal)
           when UIImageView          then view.image
           #when UITableView          then
-          #when UISwitch             then
+          when UISwitch             then view.on?
           #when UIDatePicker         then
           #when UISegmentedControl   then
           #when UIRefreshControl     then

--- a/spec/actions.rb
+++ b/spec/actions.rb
@@ -161,8 +161,11 @@ describe 'actions' do
   it 'reads and sets data for UISwitch' do
     switchy = rmq.create(UISwitch).data(true)
     switchy.get.isOn.should == true
+    switchy.data.should == true
+    # change it
     switchy.data(false)
     switchy.get.isOn.should == false
+    switchy.data.should == false
   end
 
   it 'reads and sets data for UIProgressView' do


### PR DESCRIPTION
seems @fvonhoven found a small oversight on `.data` not being able to read switch status.

Fixed here, with tests.