### PR TITLE
Fix simulator detection for iOS9. fixes #293

### DIFF
--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -90,7 +90,7 @@ module RubyMotionQuery
       end
 
       def simulator?
-        @_simulator = !(UIDevice.currentDevice.model =~ /simulator/i).nil? if @_simulator.nil?
+        @_simulator = !(NSBundle.mainBundle.bundlePath.start_with? '/var/') if @_simulator.nil?
         @_simulator
       end
 


### PR DESCRIPTION
Starting with iOS9 the simulator no longer announces itself as
'iPhone Simulator' so checking the model name won't work anymore.
