### PR TITLE
Fix device simulator

### DIFF
--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -90,8 +90,12 @@ module RubyMotionQuery
       end
 
       def simulator?
-        @_simulator = !(NSBundle.mainBundle.bundlePath.start_with? '/var/') if @_simulator.nil?
-        @_simulator
+        @_simulator ||= begin
+          if ios_at_least(9.0)
+            !NSBundle.mainBundle.bundlePath.start_with?('/var/')
+          else
+            !(UIDevice.currentDevice.model =~ /simulator/i).nil?
+        end
       end
 
       def three_point_five_inch?

--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -90,12 +90,14 @@ module RubyMotionQuery
       end
 
       def simulator?
-        @_simulator ||= begin
-          if ios_at_least(9.0)
+        if @_simulator.nil?
+          @_simulator = if ios_at_least(9.0)
             !NSBundle.mainBundle.bundlePath.start_with?('/var/')
           else
             !(UIDevice.currentDevice.model =~ /simulator/i).nil?
+          end
         end
+        @_simulator
       end
 
       def three_point_five_inch?

--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -91,7 +91,7 @@ module RubyMotionQuery
 
       def simulator?
         if @_simulator.nil?
-          @_simulator = if ios_at_least(9.0)
+          @_simulator = if ios_at_least?(9.0)
             !NSBundle.mainBundle.bundlePath.start_with?('/var/')
           else
             !(UIDevice.currentDevice.model =~ /simulator/i).nil?

--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -80,11 +80,13 @@ module RubyMotionQuery
       end
 
       def ipad?
-        @_ipad ||= (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
+        @_ipad = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) if @_ipad.nil?
+        @_ipad
       end
 
       def iphone?
-        @_iphone ||= (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
+        @_iphone = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) if @_iphone.nil?
+        @_iphone
       end
 
       def simulator?
@@ -97,26 +99,32 @@ module RubyMotionQuery
       end
 
       def three_point_five_inch?
-        @_three_point_five_inch ||= (Device.height == 480.0)
+        @_three_point_five_inch = (Device.height == 480.0) if @_three_point_five_inch.nil?
+        @_three_point_five_inch
       end
 
       def four_inch?
-        @_four_inch ||= (Device.height == 568.0)
+        @_four_inch = (Device.height == 568.0) if @_four_inch.nil?
+        @_four_inch
       end
 
       def four_point_seven_inch?
-        @_four_point_seven_inch ||= (Device.height == 667.0)
+        @_four_point_seven_inch = (Device.height == 667.0) if @_four_point_seven_inch.nil?
+        @_four_point_seven_inch
       end
 
       def five_point_five_inch?
-        @_five_point_five_inch ||= (Device.height == 736.0)
+        @_five_point_five_inch = (Device.height == 736.0) if @_five_point_five_inch.nil?
+        @_five_point_five_inch
       end
 
       def retina?
-        @_retina ||= begin
+        if @_retina.nil?
           main_screen = Device.screen
-          !!(main_screen.respondsToSelector('displayLinkWithTarget:selector:') && main_screen.scale == 2.0)
+          @_retina = !!(main_screen.respondsToSelector('displayLinkWithTarget:selector:') && main_screen.scale == 2.0)
         end
+
+        @_retina
       end
 
       # @return :unknown or from ORIENTATIONS

--- a/motion/ruby_motion_query/device.rb
+++ b/motion/ruby_motion_query/device.rb
@@ -80,13 +80,11 @@ module RubyMotionQuery
       end
 
       def ipad?
-        @_ipad = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) if @_ipad.nil?
-        @_ipad
+        @_ipad ||= (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
       end
 
       def iphone?
-        @_iphone = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) if @_iphone.nil?
-        @_iphone
+        @_iphone ||= (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
       end
 
       def simulator?
@@ -99,32 +97,26 @@ module RubyMotionQuery
       end
 
       def three_point_five_inch?
-        @_three_point_five_inch = (Device.height == 480.0) if @_three_point_five_inch.nil?
-        @_three_point_five_inch
+        @_three_point_five_inch ||= (Device.height == 480.0)
       end
 
       def four_inch?
-        @_four_inch = (Device.height == 568.0) if @_four_inch.nil?
-        @_four_inch
+        @_four_inch ||= (Device.height == 568.0)
       end
 
       def four_point_seven_inch?
-        @_four_point_seven_inch = (Device.height == 667.0) if @_four_point_seven_inch.nil?
-        @_four_point_seven_inch
+        @_four_point_seven_inch ||= (Device.height == 667.0)
       end
 
       def five_point_five_inch?
-        @_five_point_five_inch = (Device.height == 736.0) if @_five_point_five_inch.nil?
-        @_five_point_five_inch
+        @_five_point_five_inch ||= (Device.height == 736.0)
       end
 
       def retina?
-        if @_retina.nil?
+        @_retina ||= begin
           main_screen = Device.screen
-          @_retina = !!(main_screen.respondsToSelector('displayLinkWithTarget:selector:') && main_screen.scale == 2.0)
+          !!(main_screen.respondsToSelector('displayLinkWithTarget:selector:') && main_screen.scale == 2.0)
         end
-
-        @_retina
       end
 
       # @return :unknown or from ORIENTATIONS


### PR DESCRIPTION
Fixes `device.simulator?` for devices older than iOS 9. Based on https://github.com/rubymotion/BubbleWrap/pull/481

I also moved over to `||=` syntax instead of checking if the vars are nil for many of the methods in `device`.