### PR TITLE
New Feature: centering views together

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fast, non-polluting, chaining, front-end library. It’s like jQuery for [Ruby
 
 One of RMQ's goals is to have the best [documentation][1] of any RubyMotion UI library.
 
-RMQ is maintained by ![Infinite Red](http://infinite.red), a web and mobile development company based in Portland, OR and San Francisco, CA.
+RMQ is maintained by [Infinite Red](http://infinite.red), a web and mobile development company based in Portland, OR and San Francisco, CA.
 
 <br />
 

--- a/motion/ruby_motion_query/position.rb
+++ b/motion/ruby_motion_query/position.rb
@@ -106,6 +106,41 @@ module RubyMotionQuery
       self
     end
 
+    def center(type = :vertical, params = {})
+      return 0 if selected.length == 0
+
+      if Array(selected.rmq.superview.get).uniq.count > 1
+        puts "Sorry, center can only be used on selected views with the same superview."
+        return 0
+      end
+
+      if type == :vertical ||  type == :vertically
+        total_height = selected.first.superview.rmq.frame.height
+        top = selected.map{|view| view.rmq.frame.t }.min
+        bottom = selected.map{|view| view.rmq.frame.b }.max
+        elements_height = bottom - top
+
+        add = (total_height / 2) - (elements_height / 2)
+
+        selected.each do |view|
+          view.rmq.nudge(down: add)
+        end
+      else
+        total_width = selected.first.superview.rmq.frame.width
+        left = selected.map{|view| view.rmq.frame.l }.min
+        right = selected.map{|view| view.rmq.frame.r }.max
+        elements_width = right - left
+
+        add = (total_width / 2) - (elements_width / 2)
+
+        selected.each do |view|
+          view.rmq.nudge(right: add)
+        end
+      end
+
+      self
+    end
+
     def resize_frame_to_fit_subviews(args = {})
       selected.each do |view|
         view.rmq.layout(subviews_bottom_right(view, args))

--- a/spec/position.rb
+++ b/spec/position.rb
@@ -271,4 +271,89 @@ describe 'position' do
 
     @vc.rmq(view, view_2).location_in_root_view.should == [CGPoint.new(10, 20),CGPoint.new(20, 40)]
   end
+
+  it 'should return 0 when trying to center views without a common superview' do
+    view = @vc.rmq.append(UIView).layout(:full)
+    view_1 = view.append(UIView)
+    view_2 = @vc.rmq.append(UIView)
+
+    @vc.rmq(view_1, view_2).center(:vertical).should == 0
+  end
+
+  it "should center multiple views vertically" do
+    view = @vc.rmq.append(UIView).layout(:full)
+    view_1 = view.append(UIView).layout(t:0, l:0, w: 10, h: 10).get
+    view_2 = view.append(UIView).layout(t:10, l:0, w: 10, h: 10).get
+    view_3 = view.append(UIView).layout(t:20, l:0, w: 10, h: 10).get
+
+    view_1.rmq.frame.t.should == 0
+    view_2.rmq.frame.t.should == 10
+    view_3.rmq.frame.t.should == 20
+
+    @vc.rmq(view_1, view_2, view_3).center(:vertical)
+
+    center = (view.rmq.frame.height / 2) - (30 / 2)
+
+    view_1.rmq.frame.top.should == center
+    view_2.rmq.frame.top.should == center + 10
+    view_3.rmq.frame.top.should == center + 20
+  end
+
+  it "should center multiple views horizontally" do
+    view = @vc.rmq.append(UIView).layout(:full)
+    view_1 = view.append(UIView).layout(t:0, l:0, w: 10, h: 10).get
+    view_2 = view.append(UIView).layout(t:0, l:10, w: 10, h: 10).get
+    view_3 = view.append(UIView).layout(t:0, l:20, w: 10, h: 10).get
+
+    view_1.rmq.frame.l.should == 0
+    view_2.rmq.frame.l.should == 10
+    view_3.rmq.frame.l.should == 20
+
+    @vc.rmq(view_1, view_2, view_3).center(:horizontal)
+
+    center = (view.rmq.frame.width / 2) - (30 / 2)
+
+    view_1.rmq.frame.left.should == center
+    view_2.rmq.frame.left.should == center + 10
+    view_3.rmq.frame.left.should == center + 20
+  end
+
+  it "should center multiple views vertically when they have spacing" do
+    view = @vc.rmq.append(UIView).layout(:full)
+    view_1 = view.append(UIView).layout(t:0, l:0, w: 10, h: 10).get
+    view_2 = view.append(UIView).layout(t:40, l:0, w: 10, h: 10).get
+    view_3 = view.append(UIView).layout(t:90, l:0, w: 10, h: 10).get
+
+    view_1.rmq.frame.t.should == 0
+    view_2.rmq.frame.t.should == 40
+    view_3.rmq.frame.t.should == 90
+
+    @vc.rmq(view_1, view_2, view_3).center(:vertical)
+
+    center = (view.rmq.frame.height / 2) - (100 / 2)
+
+    view_1.rmq.frame.top.should == center
+    view_2.rmq.frame.top.should == center + 40
+    view_3.rmq.frame.top.should == center + 90
+  end
+
+  it "should center multiple views horizontally" do
+    view = @vc.rmq.append(UIView).layout(:full)
+    view_1 = view.append(UIView).layout(t:0, l:0, w: 10, h: 10).get
+    view_2 = view.append(UIView).layout(t:0, l:70, w: 10, h: 10).get
+    view_3 = view.append(UIView).layout(t:0, l:123, w: 10, h: 10).get
+
+    view_1.rmq.frame.l.should == 0
+    view_2.rmq.frame.l.should == 70
+    view_3.rmq.frame.l.should == 123
+
+    @vc.rmq(view_1, view_2, view_3).center(:horizontal)
+
+    center = (view.rmq.frame.width / 2) - (133.0 / 2.0)
+
+    view_1.rmq.frame.left.should == center
+    view_2.rmq.frame.left.should == center + 70
+    view_3.rmq.frame.left.should == center + 123
+  end
+
 end


### PR DESCRIPTION
This feature allows you to select multiple views (that must be contained within the same superview or the feature will not work) and center them in their superview either vertically or horizontally in that superview.

Example usage:

```ruby
rmq(:view_1, :view_2).center(:vertical)
```

This will center both views in the superview keeping their current vertical separation.

It's basically group centering. :)

With comprehensive tests.